### PR TITLE
Fixed binaryen Path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ clean:
 
 # To build binaryen
 binaryen:
-	cd src/binaryen && cmake . && make
+	cd external/binaryen && cmake . && make
 
 # To install binaryen
 installBinaryen:
-	if [ -d "/usr/lib64" ]; then cp src/binaryen/lib/libbinaryen.so /usr/lib64/; else cp src/binaryen/lib/libbinaryen.so /usr/lib/; fi
+	if [ -d "/usr/lib64" ]; then cp external/binaryen/lib/libbinaryen.so /usr/lib64/; else cp external/binaryen/lib/libbinaryen.so /usr/lib/; fi
 
 # To install wasmdec
 install:


### PR DESCRIPTION
The `binaryen` code has been moved from `src` to `external` but `Makefile` was not updated properly. It causes a compilation error and this PR fixes the problem.